### PR TITLE
Fixes detection of ordered lists

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -243,7 +243,7 @@ public class SwiftyLineProcessor {
 }
 
 func processOrderListRegex(_ text: String) -> String {
-    let regex = try? NSRegularExpression(pattern: "^[0-9]+. ", options: .caseInsensitive)
+    let regex = try? NSRegularExpression(pattern: "^[0-9]+\\. ", options: .caseInsensitive)
     let range = NSMakeRange(0, text.count)
     let result = regex?.stringByReplacingMatches(in: text, options: [], range: range,
                                                  withTemplate: "1. ")


### PR DESCRIPTION
The dot in the regex has to be escaped to really match a dot and not any character.
